### PR TITLE
CPP-442 Upgrade GitHub repos from master to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Based on https://github.com/github/gitignore/blob/master/Node.gitignore
+# Based on https://github.com/github/gitignore/blob/HEAD/Node.gitignore
 
 # Logs
 logs


### PR DESCRIPTION
[Ticket CPP-442 Upgrade GitHub repos from `master` to `main`](https://financialtimes.atlassian.net/browse/CPP-442)<br/><br/>As an organisation we are moving away from the usage of `master` as a central branch and switching it to `main`, this is to avoid using unnecessary language that can be offensive.